### PR TITLE
Use asset folders for groups

### DIFF
--- a/GroupBoundAssets/bootstrap.php
+++ b/GroupBoundAssets/bootstrap.php
@@ -14,24 +14,3 @@ if( !empty($app['app.assets.base']) ){
 } else{
     $app['app.assets.base'] = ['/addons/GroupBoundAssets/assets/js/GroupBoundAssets.js'];
 }
-
-$app->on('cockpit.assets.list', function(&$assets) {
-   
-    $accs = $this->storage->find('cockpit/accounts'); // get all accs
-
-    $nuArray = [];
-    foreach ($assets as $i => $asset) { // iterate all assets
-        // determine the group of the user that uploaded the asset
-        foreach ($accs as $i => $acc) {
-            if ($acc['_id'] === $asset['_by']) // ... when found
-                $asset['user_group'] = $acc['group']; // ... assign the found group name to the asset
-        }
-
-        // check if the current assets was created by someone with the same group as the logged in user; if so: put the current's iteration asset to a temp array
-        if($asset['user_group'] === $this["user"]['group'] || $this->module('cockpit')->isSuperAdmin())
-            $nuArray[] = $asset;
-    }
-
-    $assets->exchangeArray($nuArray); // exchange the list of assets with the processed list; this is necessary because using ->offsetUnset leaves the array like this: [0=>...,3=>...] and this will make cockpit think there are no entries
-
-});


### PR DESCRIPTION
This PR changes the base premise of how this plugin works.

Instead of checking which user created the asset, it creates an asset folder with the name of the group and forces all users into their respective folder if no other folder was selected.

This seems to work right now, but the branch has some problems nevertheless:

* If a user manipulates their requests / JS somehow, they can probably gain access to other groups folders - if they know the folder ID that is. I haven't tried it myself and it might not be a big concern.
* As cockpit does not offer any events that include the folders and allows manipulation of those, the only way I could see to force cockpit to do what I wanted was to manually add query parameters in the global $_REQUEST variable. Not very clean, but it keeps me from overriding half of the cockpit asset library. Though I'm not sure if this makes the addon more likely or less likely to break down the road with future cockpit updates.
* Cockpit does not delete files if you delete a folder. They are just moved to the root instead. I'm thinking about changing this and have all files and subfolders be deleted from that folder. Though I'm not sure about that yet.

Let me know if you are interested in this, otherwise I'll just keep the changes to my own repo.

Fixes #3 

EDIT: I added another problem to the above list!